### PR TITLE
Support base64 for darwin

### DIFF
--- a/generate_template.sh
+++ b/generate_template.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 function generate {
-    CA_BUNDLE=$(cat ./install/kustomize/base/certs/webhook.crt | base64 -w0)
+    [ $(uname) == "Darwin" ] && OPT="-b0" || OPT="-w0"
+    CA_BUNDLE=$(cat ./install/kustomize/base/certs/webhook.crt | base64 ${OPT})
     NAMESPACE=$1
     sed -e "s/CA_BUNDLE/${CA_BUNDLE}/" -e "s/NAMESPACE/${NAMESPACE}/" ./install/kustomize/mutating-webhook-configuration.yaml.tpl > ./install/kustomize/mutating-webhook-configuration.yaml
     sed -e "s/NAMESPACE/${NAMESPACE}/" ./install/kustomize/kustomization.yaml.tpl > ./install/kustomize/kustomization.yaml


### PR DESCRIPTION
Mac OS's base64 doesn't support `-w` option. Use `-b` option as an alternative.