### PR TITLE
Add custom env

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Please specify these annotations to your pods like [this](example/deployment.yam
 | [fluentd-sidecar-injector.h3poteto.dev/time-key](#time-key)                       | optional | `time`                            |
 | [fluentd-sidecar-injector.h3poteto.dev/time-format](#time-format)                 | optional | `%Y-%m-%dT%H:%M:%S%z`             |
 | [fluentd-sidecar-injector.h3poteto.dev/log-format](#log-format)                   | optional | `json`                            |
+| [fluentd-sidecar-injector.h3poteto.dev/custom-env](#custom-env)                   | optional | ""                                |
 
 - <a name="injection">`fluentd-sidecar-injector.h3poteto.dev/injection`<a/> specifies whether enable or disable this injector. Please specify `enabled` if you want to enable.
 
@@ -143,6 +144,7 @@ Please specify these annotations to your pods like [this](example/deployment.yam
 - <a name="time-key">`fluentd-sidecar-injector.h3poteto.dev/time-key`</a> is fluentd configuration in [here](https://github.com/h3poteto/docker-fluentd-forward/blob/master/fluent.conf#L6). Default is `time`.
 - <a name="time-format">`fluentd-sidecar-injector.h3poteto.dev/time-format`</a> is fluentd configuration in [here](https://github.com/h3poteto/docker-fluentd-forward/blob/master/fluent.conf#L7). Default is `%Y-%m-%dT%H:%M:%S%z`.
 - <a name="log-format">`fluentd-sidecar-injector.h3poteto.dev/log-format`</a> is fluentd configuration in [here](https://github.com/h3poteto/docker-fluentd-forward/blob/master/fluent.conf#L5). Default is `json`.
+- <a name="custom-env">`fluentd-sidecar-injector.h3poteto.dev/custom-env`</a> is an option that allows users to set their own values ​​in fluent.conf. Use with config-volume option.
 
 ## Environment variables
 

--- a/server/server.go
+++ b/server/server.go
@@ -27,6 +27,7 @@ type Env struct {
 	AggregatorHost    string `envconfig:"AGGREGATOR_HOST"`
 	AggregatorPort    string `envconfig:"AGGREGATOR_PORT" default:"24224"`
 	LogFormat         string `envconfig:"LOG_FORMAT" default:"json"`
+	CustomEnv         string `envconfig:"CUSTOM_ENV"`
 }
 
 // StartServer run webhook server.
@@ -164,6 +165,18 @@ func sidecarInjectMutator(_ context.Context, obj metav1.Object) (stop bool, err 
 		sidecar.Env = append(sidecar.Env, corev1.EnvVar{
 			Name:  "LOG_FORMAT",
 			Value: logFormat,
+		})
+	}
+
+	customEnv := fluentdEnv.CustomEnv
+	if value, ok := pod.Annotations[annotationPrefix+"/custom-env"]; ok {
+		customEnv = value
+	}
+
+	if len(customEnv) > 0 {
+		sidecar.Env = append(sidecar.Env, corev1.EnvVar{
+			Name:  "CUSTOM_ENV",
+			Value: customEnv,
 		})
 	}
 


### PR DESCRIPTION
ref: #64 

custom-env option can be freely set in the fluent.conf created by the user.

As a use case, if you are using multiple modules, you may want to set app-specific values.

```
# CUSTOM_ENV=<hoge-front | hoge-api>
<filter access_log>
  @type record_transformer
  enable_ruby
  auto_typecast true
  <record>
    app_name "#{ENV['CUSTOM_ENV']}"
  </record>
</filter>
```

