### PR TITLE
Optimize docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
-FROM golang:1.13.7-alpine3.11
+FROM golang:1.13.7-alpine3.11 as builder
+
+ENV CGO_ENABLED="0" \
+    GOOS="linux" \
+    GOARCH="amd64"
 
 WORKDIR /go/src/github.com/h3poteto/fluentd-sidecar-injector
 
-COPY . .
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
 
+COPY . .
 RUN set -ex && \
     go build -o fluentd-sidecar-injector
 
-CMD ["./fluentd-sidecar-injector"]
+FROM alpine:latest
+COPY --from=builder /go/src/github.com/h3poteto/fluentd-sidecar-injector /fluentd-sidecar-injector
+
+CMD ["/fluentd-sidecar-injector"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.7-alpine3.11 as builder
+FROM golang:1.14.4-alpine3.12 as builder
 
 ENV CGO_ENABLED="0" \
     GOOS="linux" \


### PR DESCRIPTION
Reduce the docker image size by 94% with multistep build.

```
h3poteto/fluentd-sidecar-injector optimize 29.5MB
h3poteto/fluentd-sidecar-injector now         571MB
```