### PR TITLE
Remove prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,15 +219,15 @@ Please specify these annotations to your pods like [this](example/deployment.yam
 
 If you use same parameters for all sidecar fluentd containers which are injected by this webhook, you can set the parameters with environment variables. If you want to specify these environment variables, please customize [kustomize template](install/kustomize/base/deployment.yaml).
 
-| Name                                                | Default                           |
-| --------------------------------------------------- | --------------------------------- |
-| [FLUENTD_DOCKER_IMAGE](#docker-image)               | `h3poteto/fluentd-forward:latest` |
-| [FLUENTD_AGGREGATOR_HOST](#aggregator-host)         | ""                                |
-| [FLUENTD_AGGREGATOR_PORT](#aggregator-port)         | `24224`                           |
-| [FLUENTD_APPLICATION_LOG_DIR](#application-log-dir) | ""                                |
-| [FLUENTD_TAG_PREFIX](#tag-prefix)                   | `app`                             |
-| [FLUENTD_TIME_KEY](#time-key)                       | `time`                            |
-| [FLUENTD_TIME_FORMAT](#time-format)                 | `%Y-%m-%dT%H:%M:%S%z`             |
+| Name                                        | Default                           |
+| ------------------------------------------- | --------------------------------- |
+| [DOCKER_IMAGE](#docker-image)               | `h3poteto/fluentd-forward:latest` |
+| [AGGREGATOR_HOST](#aggregator-host)         | ""                                |
+| [AGGREGATOR_PORT](#aggregator-port)         | `24224`                           |
+| [APPLICATION_LOG_DIR](#application-log-dir) | ""                                |
+| [TAG_PREFIX](#tag-prefix)                   | `app`                             |
+| [TIME_KEY](#time-key)                       | `time`                            |
+| [TIME_FORMAT](#time-format)                 | `%Y-%m-%dT%H:%M:%S%z`             |
 
 Note: these parameters will be overrided with Pod annotations if you set.
 

--- a/install/kustomize/base/deployment.yaml
+++ b/install/kustomize/base/deployment.yaml
@@ -24,8 +24,8 @@ spec:
             - --tls-cert-file=/etc/webhook/certs/cert.pem
             - --tls-key-file=/etc/webhook/certs/key.pem
           env:
-          # These parameters can be overrided by Pod's annotations.
-            - name: FLUENTD_DOCKER_IMAGE
+            # These parameters can be overrided by Pod's annotations.
+            - name: DOCKER_IMAGE
               value: h3poteto/fluentd-forward:latest
           volumeMounts:
             - name: webhook-certs


### PR DESCRIPTION
If the `FLUENT` prefix is present in the implementation, It will be not work.
So it should be removed.

https://github.com/h3poteto/fluentd-sidecar-injector/blob/9f8a5f81623b2ecd2cef925717754b5136c48c7e/server/server.go#L24-L31