### PR TITLE
Fix path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ RUN set -ex && \
     go build -o fluentd-sidecar-injector
 
 FROM alpine:latest
-COPY --from=builder /go/src/github.com/h3poteto/fluentd-sidecar-injector /fluentd-sidecar-injector
+COPY --from=builder /go/src/github.com/h3poteto/fluentd-sidecar-injector/fluentd-sidecar-injector /fluentd-sidecar-injector
 
 CMD ["/fluentd-sidecar-injector"]


### PR DESCRIPTION
ref: #67 

I fix error below.
Sorry for the inconvenience.

```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/fluentd-sidecar-injector\": permission denied": unknown.
```