### PR TITLE
Support for fluent-bit multiple config files

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -263,9 +263,7 @@ func injectFluentD(pod *corev1.Pod) (bool, error) {
 			if name := volumes[i].Name; name == value {
 				sidecar.VolumeMounts = append(sidecar.VolumeMounts, corev1.VolumeMount{
 					Name:      name,
-					MountPath: "/fluentd/etc/fluent.conf",
-					SubPath:   "fluent.conf",
-				})
+					MountPath: "/fluentd/etc" })
 				break
 			}
 		}

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -526,8 +526,7 @@ func injectFluentBit(pod *corev1.Pod) (bool, error) {
 			if name := volumes[i].Name; name == value {
 				sidecar.VolumeMounts = append(sidecar.VolumeMounts, corev1.VolumeMount{
 					Name:      name,
-					MountPath: "/fluent-bit/etc"
-				})
+					MountPath: "/fluent-bit/etc" })
 				break
 			}
 		}

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -526,8 +526,7 @@ func injectFluentBit(pod *corev1.Pod) (bool, error) {
 			if name := volumes[i].Name; name == value {
 				sidecar.VolumeMounts = append(sidecar.VolumeMounts, corev1.VolumeMount{
 					Name:      name,
-					MountPath: "/fluent-bit/etc/fluent-bit.conf",
-					SubPath:   "fluent-bit.conf",
+					MountPath: "/fluent-bit/etc"
 				})
 				break
 			}

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -190,7 +190,7 @@ func TestInjectFluentDDWithAnnotations(t *testing.T) {
 	if log := findMount(container.VolumeMounts, VolumeName); log.MountPath != "/var/log/nginx" {
 		t.Errorf("Container volume mount path is not matched: %v", log)
 	}
-	if config := findMount(container.VolumeMounts, "my-custom-volume"); config.MountPath != "/fluentd/etc/fluent.conf" {
+	if config := findMount(container.VolumeMounts, "my-custom-volume"); config.MountPath != "/fluentd/etc" {
 		t.Errorf("Container volume mount custom config is not matched: %#v", config)
 	}
 }

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -439,7 +439,7 @@ func TestInjectFluentBitWithAnnotations(t *testing.T) {
 	if log := findMount(container.VolumeMounts, VolumeName); log.MountPath != "/var/log/nginx" {
 		t.Errorf("Container volume mount path is not matched: %v", log)
 	}
-	if config := findMount(container.VolumeMounts, "my-custom-config"); config.MountPath != "/fluent-bit/etc/fluent-bit.conf" {
+	if config := findMount(container.VolumeMounts, "my-custom-config"); config.MountPath != "/fluent-bit/etc" {
 		t.Errorf("Container volume mount custom config is not matched: %#v", config)
 	}
 }


### PR DESCRIPTION
fluent-bit configuration has multiple configuration 
- Parser plugin configuration has to be provided as a separate file through `Parsers_File` option of the main config __[SERVICE]__ section 
- `@INCLUDE` option  allows also to split the main config file in multiple ones.

In order to support those, the ConfigMap cannot be mounted using `SubPath: fluent-bit.conf` but instead should be mounted on the `/fluent-bit/etc` parent directory for all config files provided in the map to be made available